### PR TITLE
Change groupId to io.microprofile.showcase for config dependencies

### DIFF
--- a/microservice-vote/vote-service-wlpcfg/pom.xml
+++ b/microservice-vote/vote-service-wlpcfg/pom.xml
@@ -21,7 +21,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>microprofile-conference</groupId>
+            <groupId>io.microprofile.showcase</groupId>
             <artifactId>${warName}</artifactId>
             <version>${warVersion}</version>
             <type>war</type>
@@ -39,7 +39,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>microprofile-conference</groupId>
+            <groupId>io.microprofile.showcase</groupId>
             <artifactId>${warName}</artifactId>
             <version>${warVersion}</version>
             <classifier>classes</classifier>


### PR DESCRIPTION
Changed groupId for dependencies from microprofile-conference to io.microprofile.showcase to fix failing compilation