### PR TITLE
As per the instructions provided in the README doc,

### DIFF
--- a/web-application/pom.xml
+++ b/web-application/pom.xml
@@ -238,6 +238,7 @@
                                 </goals>
                                 <configuration>
                                     <outputDirectory>${basedir}/src/main/static</outputDirectory>
+                                    <overwrite>true</overwrite>
                                     <resources>
                                         <resource>
                                             <directory>src/main/start/static</directory>


### PR DESCRIPTION
Build, package and run all services and the UI:

`mvn clean package -Pstart`

The web application is not able to render the data from the REST resources and the reason for this is

copy `~/micro-profile/web-application/src/main/start/static/app/shared/endpoints.service.ts` to `~/micro-profile/web-application/src/main/static/app/shared/endpoints.service.ts`
is not happening.

As per the maven resource plugin, overwrite attribute has default value "false" for copy-resources.
As part of the fix making "overwrite" as "true"