### PR TITLE
Get mvn clean to delete node_modules

### DIFF
--- a/web-application/pom.xml
+++ b/web-application/pom.xml
@@ -87,8 +87,19 @@
                     <workingDirectory>src/main/static</workingDirectory>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>src/main/static/node_modules</directory>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
         </plugins>
+        
     </build>
 
     <profiles>


### PR DESCRIPTION
To fix issue #97 mvn clean now deletes node_modules so that when there is
a version update it will refresh all the node modules