### PR TITLE
Schedule page

### DIFF
--- a/start/pom.xml
+++ b/start/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016 Microprofile.io
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+~ Copyright 2016 Microprofile.io
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~     http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -31,28 +31,28 @@
     <name>Conference :: Start</name>
     
     <profiles>
-    	<profile>
-    		<id>windowsExtensions</id>
-    		<activation>
-      			<os>
-        			<family>Windows</family>
-      			</os>
-    		</activation>
-    		<properties>
-      			<command.extension>.cmd</command.extension>
-    		</properties>
-    	</profile>
-    	<profile>
-    		<id>nonWindowsExtensions</id>
-    		<activation>
-      			<os>
-        			<family>!Windows</family>
-      			</os>
-    		</activation>
-    		<properties>
-      			<command.extension></command.extension>
-    		</properties>
-    	</profile>
+        <profile>
+            <id>windowsExtensions</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <command.extension>.cmd</command.extension>
+            </properties>
+        </profile>
+        <profile>
+            <id>nonWindowsExtensions</id>
+            <activation>
+                <os>
+                    <family>!Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <command.extension></command.extension>
+            </properties>
+        </profile>
         <profile>
             <id>start</id>
             <build>
@@ -128,7 +128,7 @@
                                 </configuration>
                             </execution>
                             <execution>
-                            <id>vote</id>
+                                <id>vote</id>
                                 <phase>package</phase>
                                 <goals>
                                     <goal>exec</goal>
@@ -143,22 +143,28 @@
                                     </arguments>
                                 </configuration>
                             </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>1.0</version>
+                        <executions>
                             <execution>
                                 <id>ui</id>
                                 <phase>package</phase>
                                 <goals>
-                                    <goal>exec</goal>
+                                    <goal>npm</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>npm${command.extension}</executable>
                                     <workingDirectory>../web-application/src/main/static</workingDirectory>
-                                    <arguments>
-                                        <argument>run</argument>
-                                        <argument>lite</argument>
-                                    </arguments>
+                                    <arguments>run lite</arguments>
                                 </configuration>
                             </execution>
                         </executions>
+                        <configuration>
+                            <installDirectory>${user.home}/.microprofile/node-installation-dir</installDirectory>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/web-application/src/main/static/app/schedule/schedules.component.html
+++ b/web-application/src/main/static/app/schedule/schedules.component.html
@@ -18,6 +18,7 @@
         </div>
     </div>
     <div class="row">
-        <p-schedule [events]="events" [header]="header"></p-schedule>
+        <p-schedule #schedule [events]="events" [header]="header" [defaultDate]="defaultDate" 
+            [defaultView]="defaultView" [allDaySlot]="allDaySlot" [minTime]="minTime" [maxTime]="maxTime"></p-schedule>
     </div>
 </div>


### PR DESCRIPTION
Connected Schedule service with the UI to show real events from it instead of mock events.
Improved UI so that it shows week agenda instead of month, and added buttons to focus on a single day and move between days.
Still to do: 
 - event titles show venue instead of session title (this is not available in the Schedule service and must be pulled from the Session sevice
 - link events in schedule page with session page to show session details on click