### PR TITLE
changed artifact ID of microprofile-schedule to ROOT 

### DIFF
--- a/microservice-schedule/pom.xml
+++ b/microservice-schedule/pom.xml
@@ -26,7 +26,7 @@
         <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>microservice-schedule</artifactId>
+    <artifactId>ROOT</artifactId>
     <name>Conference :: Schedule</name>
     <packaging>war</packaging>
 


### PR DESCRIPTION
so that Payara deploys to the root context.

Unfortunately, this is (currently) the only way. It means the artifact that comes out of Maven is named ROOT.jar.

Maybe someone with more Maven skills than me could change the name of it after the Uber JAR is created, but I wouldn't know how to do that.