### PR TITLE
Move to standardised ROOT.war file name

### DIFF
--- a/microservice-vote/pom.xml
+++ b/microservice-vote/pom.xml
@@ -319,7 +319,7 @@
                             <resource>
                               <directory>${project.build.directory}</directory>
                               <includes>
-                                <include>${project.artifactId}.war</include>
+                                <include>ROOT.war</include>
                               </includes>
                             </resource>
                           </resources>


### PR DESCRIPTION
Looks like moving to ROOT.war for the war name broke the vote service. This is a quick and easy fix, we may want to revisit later to find a way of passing this through from the top level.

Signed-off-by: pavittr <pavittr@uk.ibm.com>