### PR TITLE
Update microservice-schedule copyright

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,0 +1,14 @@
+Unless otherwise noted, the files in this repository are
+Copyright(c) 2016-2017 IBM, Red Hat, and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/microservice-schedule/pom.xml
+++ b/microservice-schedule/pom.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016 Microprofile.io
+  ~ Copyright(c) 2016-2017 IBM, Red Hat, and others.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/CORSFilter.java
+++ b/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/CORSFilter.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright(c) 2016-2017 IBM, Red Hat, and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.microprofile.showcase.schedule;
 
 import java.io.IOException;

--- a/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/model/Schedule.java
+++ b/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/model/Schedule.java
@@ -1,12 +1,10 @@
 /*
- * Copyright 2016 Microprofile.io
+ * Copyright(c) 2016-2017 IBM, Red Hat, and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *      http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/model/adapters/DurationAdapter.java
+++ b/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/model/adapters/DurationAdapter.java
@@ -1,12 +1,10 @@
 /*
- * Copyright 2016 Microprofile.io
+ * Copyright(c) 2016-2017 IBM, Red Hat, and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *      http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/model/adapters/LocalDateAdapter.java
+++ b/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/model/adapters/LocalDateAdapter.java
@@ -1,12 +1,10 @@
 /*
- * Copyright 2016 Microprofile.io
+ * Copyright(c) 2016-2017 IBM, Red Hat, and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *      http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/model/adapters/LocalTimeAdapter.java
+++ b/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/model/adapters/LocalTimeAdapter.java
@@ -1,12 +1,10 @@
 /*
- * Copyright 2016 Microprofile.io
+ * Copyright(c) 2016-2017 IBM, Red Hat, and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *      http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/persistence/ScheduleDAO.java
+++ b/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/persistence/ScheduleDAO.java
@@ -1,12 +1,10 @@
 /*
- * Copyright 2016 Microprofile.io
+ * Copyright(c) 2016-2017 IBM, Red Hat, and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *      http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/resources/ScheduleResource.java
+++ b/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/resources/ScheduleResource.java
@@ -1,12 +1,10 @@
 /*
- * Copyright 2016 Microprofile.io
+ * Copyright(c) 2016-2017 IBM, Red Hat, and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *      http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/rest/Application.java
+++ b/microservice-schedule/src/main/java/io/microprofile/showcase/schedule/rest/Application.java
@@ -1,12 +1,10 @@
 /*
- * Copyright 2016 Microprofile.io
+ * Copyright(c) 2016-2017 IBM, Red Hat, and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *      http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/microservice-schedule/src/main/liberty/config/server.xml
+++ b/microservice-schedule/src/main/liberty/config/server.xml
@@ -1,9 +1,23 @@
+<!--
+  ~ Copyright(c) 2016-2017 IBM, Red Hat, and others.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <server description="Schedule server">
     <featureManager>
         <feature>microProfile-1.0</feature>
     </featureManager>
-    
+
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="6060" />
-    
+
     <webApplication location="ROOT.war" contextRoot="/"/>
 </server>

--- a/microservice-schedule/src/test/java/io/microprofile/showcase/schedule/resources/ScheduleResourceClientTest.java
+++ b/microservice-schedule/src/test/java/io/microprofile/showcase/schedule/resources/ScheduleResourceClientTest.java
@@ -1,12 +1,10 @@
 /*
- * Copyright 2016 Microprofile.io
+ * Copyright(c) 2016-2017 IBM, Red Hat, and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *      http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/microservice-schedule/src/test/resources/arquillian.xml
+++ b/microservice-schedule/src/test/resources/arquillian.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-  ~ Copyright 2016 Microprofile.io
+  ~ Copyright(c) 2016-2017 IBM, Red Hat, and others.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
--->
+  -->
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
   <container qualifier="arquillian-glassfish-embedded"/>
 </arquillian>


### PR DESCRIPTION
Updated the microservice-schedule module copyright, and added a global COPYRIGHT.txt to files like json/yaml that don't typically have such a header.