### PR TITLE
remove plugin liberty-maven-plugin in parent pom because is generating error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <version.payara.embedded>4.1.2.173.0.1</version.payara.embedded>
         <version.tomee>7.0.1</version.tomee>
         <version.wildfly>10.0.0.Final</version.wildfly>
-        <version.liberty>17.0.0_04</version.liberty>
+
 
         <!-- Dependencies -->
         <version.microprofile>1.2</version.microprofile>
@@ -432,17 +432,7 @@
                     <artifactId>fabric8-maven-plugin</artifactId>
                     <version>${version.fabric8.plugin}</version>
                 </plugin>
-                <plugin>
-                    <groupId>net.wasdev.wlp.maven.plugins</groupId>
-                    <artifactId>liberty-maven-plugin</artifactId>
-                    <version>${version.liberty.plugin}</version>
-                    <configuration>
-             			<install>
-                        	<type>microProfile1</type>
-                        	<version>${version.liberty}</version>
-                   		</install>
-                    </configuration>
-                </plugin>
+
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This fix repair it error:

Message: Failed to execute goal net.wasdev.wlp.maven.plugins:liberty-maven-plugin:2.1:install-server (install-liberty) on project microservice-vote

Error:

[ERROR] Failed to execute goal net.wasdev.wlp.maven.plugins:liberty-maven-plugin:2.1:install-server (install-liberty) on project microservice-vote: java.lang.IllegalArgumentException: Invalid version: 17.0.0_04